### PR TITLE
Raise RuntimeError to exit(1) on bundle update failure

### DIFF
--- a/lib/circleci/bundle/update/pr.rb
+++ b/lib/circleci/bundle/update/pr.rb
@@ -25,7 +25,9 @@ module Circleci
 
         def self.need?(git_branches)
           return false unless git_branches.include?(ENV['CIRCLE_BRANCH'])
-          system("bundle update")
+          unless system("bundle update")
+            raise "Unable to execute `bundle update`"
+          end
           `git status -sb 2> /dev/null`.include?("Gemfile.lock")
         end
         private_class_method :need?


### PR DESCRIPTION
### 背景

gemを取得できず `bundle update` の際にエラーが起きた場合でも、常に `circleci-bundle-update-pr` コマンドが正常終了してしまうため、`bundle update`に失敗した場合と、gemのupdateが全くない場合との区別が付きにくいという問題がありました。

<img width="1045" alt="ss 2016-01-18 18 08 58" src="https://cloud.githubusercontent.com/assets/1041857/12387254/972e0702-be0e-11e5-860d-d1b96638cf09.png">

※ 画像はイメージです

### やったこと

`bundle update` が失敗した場合は、`RuntimeError` で exit(1) されるようにして、CiecleCI上で `bundle update` が失敗したことが分かるようにしました。

### TODO

- [x] CircleCI上でのテスト