### PR TITLE
Add detailed instruction document to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,95 @@
 # Circleci::Bundle::Update::Pr [![Gem Version][gem-badge]][gem-link]
 
-circleci-bundle-update-pr is a script for continues bundle update. Use in CircleCI
+circleci-bundle-update-pr is an automation script for continuous bundle update and for sending a pull request via CircleCI [Nightly builds](https://circleci.com/docs/nightly-builds/).
+
+By requesting a nightly build to CircleCI with an environment variable configured in `circle.yml` to execute this script, bundle update is invoked, then commit changes and send a pull request to GitHub repository if there some changes exist.
 
 ## Installation
 
-Add this line to your application's Gemfile:
-
-```ruby
-gem 'circleci-bundle-update-pr'
+```
+$ gem install circleci-bundle-update-pr
 ```
 
-And then execute:
+## Prerequisites
 
-    $ bundle
-
-Or install it yourself as:
-
-    $ gem install circleci-bundle-update-pr
+The application on which you want to run continuous bundle update must be configured to be built on CircleCI.
 
 ## Usage
 
-    $ circleci-bundle-update-pr 'Git username' 'Git email address'
+### Setting GitHub personal access token to CircleCI
+
+GitHub personal access token is required for sending pull requests to your repository.
+
+1. Go to [your account's settings page](https://github.com/settings/tokens) and generate a personal access token with "repo" scope
+2. On CircleCI dashboard, go to your application's "Project Settings" -> "Environment Variables"
+3. Add an environment variable `GITHUB_ACCESS_TOKEN` with your GitHub personal access token
+
+### Getting CircleCI API token
+
+CircleCI API token is required to trigger nightly builds.
+
+1. Go to your application's "Project Settings" -> "API Permissions"
+2. Select "Create Token" and create a new token with "All" scope and any label you like
+
+### Configure circle.yml
+
+Configure your `circle.yml` to run `circleci-bundle-update-pr` if `BUNDLE_UPDATE` environment variable is present, for example:
+
+```yaml
+deployment:
+  production:
+    branch: master
+    commands:
+      - |
+        if [ "${BUNDLE_UPDATE}" ] ; then
+          gem update bundler --no-document
+          gem install circleci-bundle-update-pr
+          circleci-bundle-update-pr <username> <email>
+        fi
+```
+
+NOTE: Please make sure you replace `<username>` and `<email>` with yours.
+
+### Trigger nightly build API via curl
+
+The easiest way to start a nightly build is using curl. The below is a simple script to trigger a build.
+
+```bash
+_project=<username>/<reponame>
+_branch=master
+_circle_token=<ciecleci api token>
+
+trigger_build_url=https://circleci.com/api/v1/project/${_project}/tree/${_branch}?circle-token=${_circle_token}
+
+post_data='{ "build_parameters": { "BUNDLE_UPDATE": "true" } }'
+
+curl \
+  --header "Accept: application/json" \
+  --header "Content-Type: application/json" \
+  --data "${post_data}" \
+  --request POST ${trigger_build_url}
+```
+
+NOTE: Please do not forget to replace `<username>/<reponame>/<circleci api token>` with yours.
+
+
+### Trigger nightly build via ci-bundle-update (recommended)
+
+While you can trigger nightly builds by using whatever you want for sending requests to API, the most recommended way is to use "ci-bundle-update". Please see https://github.com/masutaka/ci-bundle-update for details.
+
+## CLI command references
+
+General usage:
+
+```
+$ circleci-bundle-update-pr <git username> <git email address>
+```
 
 By default, it works only on master branch, but you can also explicitly specify any branches rather than only master branch by adding them to the arguments.
 
-    $ circleci-bundle-update-pr 'Git username' 'Git email address' master develop topic
+```
+$ circleci-bundle-update-pr <git username> <git email address> master develop topic
+```
 
 ## Contributing
 


### PR DESCRIPTION
Since there is not an instruction for using circleci-bundle-update-pr on this repository itself, I have added the detailed instruction document to readme.

It is kind like the document of the following 3 instructions with mixed (and yes, translated into English):

- https://masutaka.net/chalow/2015-07-28-1.html
- http://ppworks.hatenablog.jp/entry/2015/12/23/214644
- http://qiita.com/yuku_t/items/0f8e48771822420d3ffa (for triggering builds via curl)

How does this sound to you? 😄 