### PR TITLE
Update octokit

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,25 +3,27 @@ PATH
   specs:
     circleci-bundle-update-pr (1.6.2)
       compare_linker
-      octokit (~> 3.8)
+      octokit (~> 4.7.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.3.8)
+    addressable (2.5.1)
+      public_suffix (~> 2.0, >= 2.0.2)
     compare_linker (1.3.7)
       httpclient
       octokit
-    faraday (0.9.2)
+    faraday (0.12.2)
       multipart-post (>= 1.2, < 3)
     httpclient (2.8.3)
     multipart-post (2.0.0)
-    octokit (3.8.0)
-      sawyer (~> 0.6.0, >= 0.5.3)
+    octokit (4.7.0)
+      sawyer (~> 0.8.0, >= 0.5.3)
+    public_suffix (2.0.5)
     rake (10.5.0)
-    sawyer (0.6.0)
-      addressable (~> 2.3.5)
-      faraday (~> 0.8, < 0.10)
+    sawyer (0.8.1)
+      addressable (>= 2.3.5, < 2.6)
+      faraday (~> 0.8, < 1.0)
 
 PLATFORMS
   ruby

--- a/circleci-bundle-update-pr.gemspec
+++ b/circleci-bundle-update-pr.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'octokit', '~> 3.8'
+  spec.add_dependency 'octokit', '~> 4.7.0'
   spec.add_dependency 'compare_linker'
 
   spec.add_development_dependency "bundler", "~> 1.7"


### PR DESCRIPTION
`octokit`が古いバージョンに依存しているため、`circleci-bundle-update-pr`をインストールしようとすると他のGemとコンフリクトが起きてしまいます。
`octokit`のバージョンを上げてこの状況を解決したいです。

Since `octokit` depends on the old version(~> 3.8), My app can not install `circleci-bundle-update-pr`  in conflict with other gems.
I want to solve this situation by updating `octokit`

```
Bundler could not find compatible versions for gem "addressable":
  In snapshot (Gemfile.lock):
    addressable (= 2.5.1)

  In Gemfile:

    browserify-rails (= 4.2.0) ruby depends on
      addressable (>= 2.4.0) ruby

    circleci-bundle-update-pr (>= 0) ruby depends on
      octokit (~> 3.8) ruby depends on
        sawyer (>= 0.5.3, ~> 0.6.0) ruby depends on
          addressable (~> 2.3.5) ruby

Running `bundle update` will rebuild your snapshot from scratch, using only
the gems in your Gemfile, which may resolve the conflict.
```