### PR TITLE
[new option]make pr even if it has already exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Usage: circleci-bundle-update-pr [options]
     -a, --assignees alice,bob,carol  Assign the PR to them
     -r, --reviewers alice,bob,carol  Request PR review to them
     -l, --labels "In Review, Update" Add labels to the PR
-    -d, --duplicate                  Make PR if it has already existed
+    -d, --duplicate                  Make PR even if it has already existed
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Usage: circleci-bundle-update-pr [options]
     -a, --assignees alice,bob,carol  Assign the PR to them
     -r, --reviewers alice,bob,carol  Request PR review to them
     -l, --labels "In Review, Update" Add labels to the PR
+    -d, --duplicate                  Make PR if it has already existed
 ```
 
 ## Contributing

--- a/bin/circleci-bundle-update-pr
+++ b/bin/circleci-bundle-update-pr
@@ -8,6 +8,7 @@ options = { assignees: [] }
 opt.on('-a', '--assignees alice,bob,carol', Array, 'Assign the PR to them') { |v| options[:assignees] = v.map(&:strip) }
 opt.on('-r', '--reviewers alice,bob,carol', Array, 'Request PR review to them') { |v| options[:reviewers] = v.map(&:strip) }
 opt.on('-l', '--labels "In Review, Update"', Array, 'Add labels to the PR') { |v| options[:labels] = v.map(&:strip) }
+opt.on('-d', '--duplicate', 'Make PR if it has already existed') { |v| options[:allow_dup_pr] = v }
 opt.parse!(ARGV)
 
 Circleci::Bundle::Update::Pr.create_if_needed(
@@ -17,4 +18,5 @@ Circleci::Bundle::Update::Pr.create_if_needed(
   assignees: options[:assignees],
   reviewers: options[:reviewers],
   labels: options[:labels],
+  allow_dup_pr: !!options[:allow_dup_pr]
 )

--- a/bin/circleci-bundle-update-pr
+++ b/bin/circleci-bundle-update-pr
@@ -8,7 +8,7 @@ options = { assignees: [] }
 opt.on('-a', '--assignees alice,bob,carol', Array, 'Assign the PR to them') { |v| options[:assignees] = v.map(&:strip) }
 opt.on('-r', '--reviewers alice,bob,carol', Array, 'Request PR review to them') { |v| options[:reviewers] = v.map(&:strip) }
 opt.on('-l', '--labels "In Review, Update"', Array, 'Add labels to the PR') { |v| options[:labels] = v.map(&:strip) }
-opt.on('-d', '--duplicate', 'Make PR if it has already existed') { |v| options[:allow_dup_pr] = v }
+opt.on('-d', '--duplicate', 'Make PR even if it has already existed') { |v| options[:allow_dup_pr] = v }
 opt.parse!(ARGV)
 
 Circleci::Bundle::Update::Pr.create_if_needed(


### PR DESCRIPTION
### Summary

PR has not been maked if it has already exists In the previous update.
However, I need newer one when I miss merge.
Making new update PR by myself is too much hassle and Wating next cron iteration feel so far!

So I want to add the option allow users to make duplicate bundle update PR.

### Testing
* Confirmed to make duplicate PR with `-d` option.
* Confirmed not to make duplicate PR without `-d` option.