### PR TITLE
Allow white spaces in Git user.name

### DIFF
--- a/lib/circleci/bundle/update/pr.rb
+++ b/lib/circleci/bundle/update/pr.rb
@@ -88,7 +88,7 @@ module Circleci
           branch = "#{BRANCH_PREFIX}#{now.strftime('%Y%m%d%H%M%S')}"
           remote = "https://#{github_access_token}@#{github_host}/#{repo_full_name}"
           system("git remote add github-url-with-token #{remote}")
-          system("git config user.name #{git_username}")
+          system("git config user.name '#{git_username}'")
           system("git config user.email #{git_email}")
           system("git add Gemfile.lock")
           system("git commit -m '$ bundle update && bundle update --ruby'")


### PR DESCRIPTION
## Why?

Specifying a username with white spaces in `$ circleci-bundle-update-pr <git username>` will result in unintended settings.

### When `<git username>` includes one white space

**Expect**

```
$ circleci-bundle-update-pr 'hoge fuga' example@example.com
...
$ git config user.name
hoge fuga
```

**Actual**

```
$ circleci-bundle-update-pr 'hoge fuga' example@example.com
...
$ git config user.name
hoge
```

### When `<git username>` includes more than one white space

**Expect**

```
$ circleci-bundle-update-pr 'hoge fuga piyo' example@example.com
...
$ git config user.name
hoge fuga piyo
```

**Actual**

```
$ circleci-bundle-update-pr 'hoge fuga piyo' example@example.com
...
$ git config user.name
```

And `circleci-bundle-update-pr` occurs error.
Clock [here](https://circleci.com/gh/feedforce/feedforce-ruboty/10) for more detail.

## How

* Around `#{git_username}` by single quotes

## How to check operation

Try manual unit tests.

```
$ irb
irb(main):001:0> git_username = 'hoge'
=> "hoge"
irb(main):002:0> system("git config user.name '#{git_username}'")
=> true
irb(main):003:0> system("git config user.name")
hoge
=> true
irb(main):004:0> git_username = 'hoge fuga'
=> "hoge fuga"
irb(main):005:0> system("git config user.name '#{git_username}'")
=> true
irb(main):006:0> system("git config user.name")
hoge fuga
=> true
irb(main):007:0> git_username = 'hoge fuga piyo'
=> "hoge fuga piyo"
irb(main):008:0> system("git config user.name '#{git_username}'")
=> true
irb(main):009:0> system("git config user.name")
hoge fuga piyo
=> true
```