### PR TITLE
Drop ruby-2.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,27 +23,6 @@ references:
     command: rspec
 
 jobs:
-  build_on_ruby2_2:
-    docker:
-       - image: ruby:2.2-alpine
-    working_directory: /work
-    steps:
-      - run: *setup_requirements
-      - run: *set_timezone
-      - checkout
-      - restore_cache:
-          name: Restore bundler cache
-          keys:
-            - gems-ruby2.2-{{ .Environment.COMMON_CACHE_KEY }}-{{ checksum "Gemfile.lock" }}
-            - gems-ruby2.2-{{ .Environment.COMMON_CACHE_KEY }}-
-      - run: *bundle_install
-      - save_cache:
-          name: Save bundler cache
-          key: gems-ruby2.2-{{ .Environment.COMMON_CACHE_KEY }}-{{ checksum "Gemfile.lock" }}
-          paths:
-            - /usr/local/bundle
-      - run: *rubocop
-      - run: *rspec
   build_on_ruby2_3:
     docker:
        - image: ruby:2.3-alpine
@@ -147,7 +126,6 @@ workflows:
   version: 2
   ordinary:
     jobs:
-      - build_on_ruby2_2
       - build_on_ruby2_3
       - build_on_ruby2_4
       - build_on_ruby2_5

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,7 @@ require: rubocop-rspec
 
 AllCops:
   DisplayCopNames: true
-  TargetRubyVersion: 2.2
+  TargetRubyVersion: 2.3
 
 Metrics:
   Enabled: false

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -1,4 +1,8 @@
-# Until I drop ruby-2.2 support
 Layout/IndentHeredoc:
+  Exclude:
+    - 'lib/circleci/bundle/update/pr.rb'
+
+# See also https://github.com/masutaka/circleci-bundle-update-pr/issues/84
+Style/FrozenStringLiteralComment:
   Exclude:
     - 'lib/circleci/bundle/update/pr.rb'

--- a/lib/circleci/bundle/update/pr.rb
+++ b/lib/circleci/bundle/update/pr.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require 'circleci/bundle/update/pr/version'
 require 'octokit'
 require 'compare_linker'

--- a/lib/circleci/bundle/update/pr/version.rb
+++ b/lib/circleci/bundle/update/pr/version.rb
@@ -4,7 +4,7 @@ module Circleci
   module Bundle
     module Update
       module Pr
-        VERSION = '1.15.0'.freeze
+        VERSION = '1.15.0'
       end
     end
   end


### PR DESCRIPTION
Drop unsupported ruby-2.2.
It is hard to support ruby-2.2 while fixing FrozenError.

Also I might drop ruby-2.3 soon.
https://www.ruby-lang.org/en/downloads/
