### PR TITLE
Make TITLE_PREFIX injectable from environment

### DIFF
--- a/lib/circleci/bundle/update/pr.rb
+++ b/lib/circleci/bundle/update/pr.rb
@@ -38,7 +38,7 @@ module Circleci
         end
 
         BRANCH_PREFIX = ENV['BRANCH_PREFIX'] || 'bundle-update-'.freeze
-        TITLE_PREFIX = 'bundle update at '.freeze
+        TITLE_PREFIX = ENV['TITLE_PREFIX'] || 'bundle update at '.freeze
 
         def self.raise_if_env_unvalid!
           raise "$CIRCLE_PROJECT_USERNAME isn't set" unless ENV['CIRCLE_PROJECT_USERNAME']


### PR DESCRIPTION
Suppose a project where more than one Gemfile exist in subdirectories.

Running `circleci-bundle-update-pr` within each directory(`workdir`) of these Gemfiles will create PRs with same title prefix which are difficult to distinguish from each other.  `BRANCH_PREFIX` does not help in this case because it won't appear in titles.

With configurable title prefix, `circleci-bundle-update-pr` of each directory can generate distinguishable PRs.
