### PR TITLE
git operation without system git command

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ jobs:
           name: Install System Dependencies
           command: |
             # See also https://circleci.com/docs/2.0/custom-images/#adding-required-and-custom-tools-or-files
-            apk add --update --no-cache git openssh-client tar gzip ca-certificates \
+            apk add --update --no-cache openssh-client tar gzip ca-certificates \
               tzdata
             gem install -N bundler
       - run:

--- a/lib/circleci/bundle/update/pr.rb
+++ b/lib/circleci/bundle/update/pr.rb
@@ -88,11 +88,15 @@ module Circleci
         #
         # @return [Boolean]
         def self.need_to_commit?
+          old_lockfile = File.read('Gemfile.lock')
+
           unless system('bundle update && bundle update --ruby')
             raise 'Unable to execute `bundle update && bundle update --ruby`'
           end
 
-          `git status -sb 2> /dev/null`.include?('Gemfile.lock')
+          new_lockfile = File.read('Gemfile.lock')
+
+          old_lockfile != new_lockfile
         end
         private_class_method :need_to_commit?
 
@@ -101,14 +105,42 @@ module Circleci
         # @return [String] remote branch name. e.g. bundle-update-20180929154455
         def self.create_branch(git_username, git_email)
           branch = "#{BRANCH_PREFIX}#{now.strftime('%Y%m%d%H%M%S')}"
-          remote = "https://#{github_access_token}@#{github_host}/#{repo_full_name}"
-          system("git remote add github-url-with-token #{remote}")
-          system("git config user.name '#{git_username}'")
-          system("git config user.email #{git_email}")
-          system('git add Gemfile.lock')
-          system("git commit -m '$ bundle update && bundle update --ruby'")
-          system("git branch -M #{branch}")
-          system("git push -q github-url-with-token #{branch}")
+
+          current_ref = client.ref(repo_full_name, "heads/#{ENV['CIRCLE_BRANCH']}")
+          branch_ref = client.create_ref(repo_full_name, "heads/#{branch}", current_ref.object.sha)
+
+          branch_commit = client.commit(repo_full_name, branch_ref.object.sha)
+
+          lockfile = File.read('Gemfile.lock')
+          lockfile_blob_sha = client.create_blob(repo_full_name, lockfile)
+          tree = client.create_tree(
+            repo_full_name,
+            [
+              {
+                path: 'Gemfile.lock',
+                mode: '100644',
+                type: 'blob',
+                sha: lockfile_blob_sha,
+              },
+            ],
+            base_tree: branch_commit.commit.tree.sha,
+          )
+
+          commit = client.create_commit(
+            repo_full_name,
+            '$ bundle update && bundle update --ruby',
+            tree.sha,
+            branch_ref.object.sha,
+            author: {
+              name: git_username,
+              email: git_email,
+            },
+          )
+
+          client.update_ref(repo_full_name, "heads/#{branch}", commit.sha)
+
+          puts "#{branch} is created"
+
           branch
         end
         private_class_method :create_branch


### PR DESCRIPTION
I replaced system git operation (e.g. `git commit`) with GitHub API.

# Context 1
`circleci-bundle-update-pr` is implicitly dependent on system `git`.

https://github.com/masutaka/circleci-bundle-update-pr/blob/v1.16.1/lib/circleci/bundle/update/pr.rb#L105-L111

So I want to remove this implicitly dependent.

# Context 2
I want to run `circleci-bundle-update-pr` on GitHub Actions.

`secrets.GITHUB_TOKEN`  (default token on GitHub Actions) has given permission to GitHub API , but hasn't given permission to syetem `git push`.

https://help.github.com/en/articles/virtual-environments-for-github-actions#github_token-secret

So I replaced system git operation to GitHub API operation.

## Example
![image](https://user-images.githubusercontent.com/608755/65032348-efdeb480-d97d-11e9-9ad4-ab90aa287c8e.png)

