### PR TITLE
Add main branch to default branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ General usage:
 $ circleci-bundle-update-pr <git username> <git email address>
 ```
 
-By default, it works only on master branch, but you can also explicitly specify any branches rather than only master branch by adding them to the arguments.
+By default, it works only on master or main branches, but you can also explicitly specify any branches rather than only these branches by adding them to the arguments.
 
 ```
 $ circleci-bundle-update-pr <git username> <git email address> master develop topic

--- a/bin/circleci-bundle-update-pr
+++ b/bin/circleci-bundle-update-pr
@@ -15,7 +15,7 @@ opt.parse!(ARGV)
 Circleci::Bundle::Update::Pr.create_if_needed(
   git_username: ARGV.shift,
   git_email: ARGV.shift,
-  git_branches: ARGV.empty? ? ['master'] : ARGV,
+  git_branches: ARGV.empty? ? ['master', 'main'] : ARGV,
   assignees: options[:assignees],
   reviewers: options[:reviewers],
   labels: options[:labels],

--- a/lib/circleci/bundle/update/pr.rb
+++ b/lib/circleci/bundle/update/pr.rb
@@ -7,7 +7,7 @@ module Circleci
   module Bundle
     module Update
       module Pr
-        def self.create_if_needed(git_username: nil, git_email: nil, git_branches: ['master'],
+        def self.create_if_needed(git_username: nil, git_email: nil, git_branches: ['master', 'main'],
                                   assignees: nil, reviewers: nil, labels: nil, allow_dup_pr: false)
           raise_if_env_unvalid!
 


### PR DESCRIPTION
Currently the default GitHub branch is `main`

c.f. https://github.blog/changelog/2020-10-01-the-default-branch-for-newly-created-repositories-is-now-main/