### PR TITLE
bundle update at 2022-12-01 19:03:08 JST

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,22 +15,22 @@ GEM
       httpclient
       octokit
     diff-lcs (1.5.0)
-    faraday (2.6.0)
+    faraday (2.7.1)
       faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
-    faraday-net_http (3.0.1)
+    faraday-net_http (3.0.2)
     httpclient (2.8.3)
     json (2.6.2)
-    octokit (6.0.0)
+    octokit (6.0.1)
       faraday (>= 1, < 3)
       sawyer (~> 0.9)
-    parallel (1.19.2)
-    parser (3.1.2.1)
+    parallel (1.22.1)
+    parser (3.1.3.0)
       ast (~> 2.4.1)
     public_suffix (5.0.0)
     rainbow (3.1.1)
     rake (13.0.6)
-    regexp_parser (2.6.0)
+    regexp_parser (2.6.1)
     rexml (3.2.5)
     rspec (3.12.0)
       rspec-core (~> 3.12.0)
@@ -45,7 +45,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
     rspec-support (3.12.0)
-    rubocop (1.38.0)
+    rubocop (1.39.0)
       json (~> 2.3)
       parallel (~> 1.10)
       parser (>= 3.1.2.1)
@@ -55,11 +55,11 @@ GEM
       rubocop-ast (>= 1.23.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 3.0)
-    rubocop-ast (1.23.0)
+    rubocop-ast (1.24.0)
       parser (>= 3.1.1.0)
     rubocop-rake (0.6.0)
       rubocop (~> 1.0)
-    rubocop-rspec (2.14.2)
+    rubocop-rspec (2.15.0)
       rubocop (~> 1.33)
     ruby-progressbar (1.11.0)
     ruby2_keywords (0.0.5)
@@ -86,4 +86,4 @@ DEPENDENCIES
   rubocop-rspec
 
 BUNDLED WITH
-   2.3.11
+   2.3.26


### PR DESCRIPTION
**Updated RubyGems:**

* [ ] [faraday](https://github.com/lostisland/faraday): [`2.6.0...2.7.1`](https://github.com/lostisland/faraday/compare/v2.6.0...v2.7.1)
* [ ] [faraday-net_http](https://github.com/lostisland/faraday-net_http): [`3.0.1...3.0.2`](https://github.com/lostisland/faraday-net_http/compare/v3.0.1...v3.0.2)
* [ ] [octokit](https://github.com/octokit/octokit.rb): [`6.0.0...6.0.1`](https://github.com/octokit/octokit.rb/compare/v6.0.0...v6.0.1)
* [ ] [parallel](https://github.com/grosser/parallel): [`1.19.2...1.22.1`](https://github.com/grosser/parallel/compare/v1.19.2...v1.22.1)
* [ ] [parser](https://github.com/whitequark/parser): [`3.1.2.1...3.1.3.0`](https://github.com/whitequark/parser/compare/v3.1.2.1...v3.1.3.0)
* [ ] [regexp_parser](https://github.com/ammar/regexp_parser): [`2.6.0...2.6.1`](https://github.com/ammar/regexp_parser/compare/v2.6.0...v2.6.1)
* [ ] [rubocop](https://github.com/rubocop/rubocop): [`1.38.0...1.39.0`](https://github.com/rubocop/rubocop/compare/v1.38.0...v1.39.0)
* [ ] [rubocop-ast](https://github.com/rubocop/rubocop-ast): [`1.23.0...1.24.0`](https://github.com/rubocop/rubocop-ast/compare/v1.23.0...v1.24.0)
* [ ] [rubocop-rspec](https://github.com/rubocop/rubocop-rspec): [`2.14.2...2.15.0`](https://github.com/rubocop/rubocop-rspec/compare/v2.14.2...v2.15.0)

Powered by [circleci-bundle-update-pr](https://rubygems.org/gems/circleci-bundle-update-pr)
