### PR TITLE
bundle update at 2024-05-01 19:10:44 JST

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,7 +21,7 @@ GEM
     faraday-net_http (3.1.0)
       net-http
     httpclient (2.8.3)
-    json (2.7.1)
+    json (2.7.2)
     language_server-protocol (3.17.0.3)
     net-http (0.4.1)
       uri
@@ -30,13 +30,13 @@ GEM
       faraday (>= 1, < 3)
       sawyer (~> 0.9)
     parallel (1.24.0)
-    parser (3.3.0.5)
+    parser (3.3.1.0)
       ast (~> 2.4.1)
       racc
-    public_suffix (5.0.4)
+    public_suffix (5.0.5)
     racc (1.7.3)
     rainbow (3.1.1)
-    rake (13.1.0)
+    rake (13.2.1)
     regexp_parser (2.9.0)
     rexml (3.2.6)
     rspec (3.13.0)
@@ -52,7 +52,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
     rspec-support (3.13.1)
-    rubocop (1.62.1)
+    rubocop (1.63.4)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
@@ -63,20 +63,20 @@ GEM
       rubocop-ast (>= 1.31.1, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 3.0)
-    rubocop-ast (1.31.2)
-      parser (>= 3.3.0.4)
+    rubocop-ast (1.31.3)
+      parser (>= 3.3.1.0)
     rubocop-capybara (2.20.0)
       rubocop (~> 1.41)
     rubocop-factory_bot (2.25.1)
       rubocop (~> 1.41)
     rubocop-rake (0.6.0)
       rubocop (~> 1.0)
-    rubocop-rspec (2.28.0)
+    rubocop-rspec (2.29.1)
       rubocop (~> 1.40)
       rubocop-capybara (~> 2.17)
       rubocop-factory_bot (~> 2.22)
       rubocop-rspec_rails (~> 2.28)
-    rubocop-rspec_rails (2.28.2)
+    rubocop-rspec_rails (2.28.3)
       rubocop (~> 1.40)
     ruby-progressbar (1.13.0)
     sawyer (0.9.2)
@@ -103,4 +103,4 @@ DEPENDENCIES
   rubocop-rspec
 
 BUNDLED WITH
-   2.5.3
+   2.5.9


### PR DESCRIPTION
**Updated RubyGems:**

* [ ] [json](https://github.com/flori/json): [`2.7.1...2.7.2`](https://github.com/flori/json/compare/v2.7.1...v2.7.2)
* [ ] [parser](https://github.com/whitequark/parser): [`3.3.0.5...3.3.1.0`](https://github.com/whitequark/parser/compare/v3.3.0.5...v3.3.1.0)
* [ ] [public_suffix](https://github.com/weppos/publicsuffix-ruby): [`5.0.4...5.0.5`](https://github.com/weppos/publicsuffix-ruby/compare/v5.0.4...v5.0.5)
* [ ] [rake](https://github.com/ruby/rake): [`13.1.0...13.2.1`](https://github.com/ruby/rake/compare/v13.1.0...v13.2.1)
* [ ] [rubocop](https://github.com/rubocop/rubocop): [`1.62.1...1.63.4`](https://github.com/rubocop/rubocop/compare/v1.62.1...v1.63.4)
* [ ] [rubocop-ast](https://github.com/rubocop/rubocop-ast): [`1.31.2...1.31.3`](https://github.com/rubocop/rubocop-ast/compare/v1.31.2...v1.31.3)
* [ ] [rubocop-rspec](https://github.com/rubocop/rubocop-rspec): [`2.28.0...2.29.1`](https://github.com/rubocop/rubocop-rspec/compare/v2.28.0...v2.29.1)
* [ ] rubocop-rspec_rails: (link not found) `2.28.2...2.28.3`

Powered by [circleci-bundle-update-pr](https://rubygems.org/gems/circleci-bundle-update-pr)
