### PR TITLE
bundle update at 2024-07-01 19:11:03 JST

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,15 +8,14 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.8.6)
-      public_suffix (>= 2.0.2, < 6.0)
+    addressable (2.8.7)
+      public_suffix (>= 2.0.2, < 7.0)
     ast (2.4.2)
-    base64 (0.2.0)
     compare_linker (1.4.5)
       httpclient
       octokit
     diff-lcs (1.5.1)
-    faraday (2.9.0)
+    faraday (2.9.2)
       faraday-net_http (>= 2.0, < 3.2)
     faraday-net_http (3.1.0)
       net-http
@@ -25,28 +24,27 @@ GEM
     language_server-protocol (3.17.0.3)
     net-http (0.4.1)
       uri
-    octokit (8.1.0)
-      base64
+    octokit (9.1.0)
       faraday (>= 1, < 3)
       sawyer (~> 0.9)
-    parallel (1.24.0)
-    parser (3.3.2.0)
+    parallel (1.25.1)
+    parser (3.3.3.0)
       ast (~> 2.4.1)
       racc
-    public_suffix (5.0.5)
+    public_suffix (6.0.0)
     racc (1.8.0)
     rainbow (3.1.1)
     rake (13.2.1)
     regexp_parser (2.9.2)
-    rexml (3.2.8)
-      strscan (>= 3.0.9)
+    rexml (3.3.1)
+      strscan
     rspec (3.13.0)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
       rspec-mocks (~> 3.13.0)
     rspec-core (3.13.0)
       rspec-support (~> 3.13.0)
-    rspec-expectations (3.13.0)
+    rspec-expectations (3.13.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
     rspec-mocks (3.13.1)
@@ -66,19 +64,10 @@ GEM
       unicode-display_width (>= 2.4.0, < 3.0)
     rubocop-ast (1.31.3)
       parser (>= 3.3.1.0)
-    rubocop-capybara (2.20.0)
-      rubocop (~> 1.41)
-    rubocop-factory_bot (2.25.1)
-      rubocop (~> 1.41)
     rubocop-rake (0.6.0)
       rubocop (~> 1.0)
-    rubocop-rspec (2.29.2)
-      rubocop (~> 1.40)
-      rubocop-capybara (~> 2.17)
-      rubocop-factory_bot (~> 2.22)
-      rubocop-rspec_rails (~> 2.28)
-    rubocop-rspec_rails (2.28.3)
-      rubocop (~> 1.40)
+    rubocop-rspec (3.0.1)
+      rubocop (~> 1.61)
     ruby-progressbar (1.13.0)
     sawyer (0.9.2)
       addressable (>= 2.3.5)
@@ -105,4 +94,4 @@ DEPENDENCIES
   rubocop-rspec
 
 BUNDLED WITH
-   2.5.11
+   2.5.12


### PR DESCRIPTION
**Updated RubyGems:**

* [ ] [addressable](https://github.com/sporkmonger/addressable): [`2.8.6...2.8.7`](https://github.com/sporkmonger/addressable/compare/addressable-2.8.6...addressable-2.8.7)
* [ ] [faraday](https://github.com/lostisland/faraday): [`2.9.0...2.9.2`](https://github.com/lostisland/faraday/compare/v2.9.0...v2.9.2)
* [ ] [octokit](https://github.com/octokit/octokit.rb): [`8.1.0...9.1.0`](https://github.com/octokit/octokit.rb/compare/v8.1.0...v9.1.0)
* [ ] [parallel](https://github.com/grosser/parallel): [`1.24.0...1.25.1`](https://github.com/grosser/parallel/compare/v1.24.0...v1.25.1)
* [ ] [parser](https://github.com/whitequark/parser): [`3.3.2.0...3.3.3.0`](https://github.com/whitequark/parser/compare/v3.3.2.0...v3.3.3.0)
* [ ] [public_suffix](https://github.com/weppos/publicsuffix-ruby): [`5.0.5...6.0.0`](https://github.com/weppos/publicsuffix-ruby/compare/v5.0.5...v6.0.0)
* [ ] [rexml](https://github.com/ruby/rexml): [`3.2.8...3.3.1`](https://github.com/ruby/rexml/compare/v3.2.8...v3.3.1)
* [ ] [rspec-expectations](https://github.com/rspec/rspec-expectations): [`3.13.0...3.13.1`](https://github.com/rspec/rspec-expectations/compare/v3.13.0...v3.13.1)
* [ ] [rubocop-rspec](https://github.com/rubocop/rubocop-rspec): [`2.29.2...3.0.1`](https://github.com/rubocop/rubocop-rspec/compare/v2.29.2...v3.0.1)

Powered by [circleci-bundle-update-pr](https://rubygems.org/gems/circleci-bundle-update-pr)
