### PR TITLE
bundle update at 2024-12-01 19:11:02 JST

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,31 +18,31 @@ GEM
       octokit
       ostruct
     diff-lcs (1.5.1)
-    faraday (2.12.0)
-      faraday-net_http (>= 2.0, < 3.4)
+    faraday (2.12.1)
+      faraday-net_http (>= 2.0, < 3.5)
       json
       logger
-    faraday-net_http (3.3.0)
-      net-http
+    faraday-net_http (3.4.0)
+      net-http (>= 0.5.0)
     httpclient (2.8.3)
-    json (2.7.5)
+    json (2.8.2)
     language_server-protocol (3.17.0.3)
     logger (1.6.1)
-    net-http (0.4.1)
+    net-http (0.5.0)
       uri
     octokit (9.2.0)
       faraday (>= 1, < 3)
       sawyer (~> 0.9)
-    ostruct (0.6.0)
+    ostruct (0.6.1)
     parallel (1.26.3)
-    parser (3.3.5.1)
+    parser (3.3.6.0)
       ast (~> 2.4.1)
       racc
     public_suffix (6.0.1)
     racc (1.8.1)
     rainbow (3.1.1)
     rake (13.2.1)
-    regexp_parser (2.9.2)
+    regexp_parser (2.9.3)
     rspec (3.13.0)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
@@ -56,17 +56,17 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
     rspec-support (3.13.1)
-    rubocop (1.68.0)
+    rubocop (1.69.0)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
       parser (>= 3.3.0.2)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 2.4, < 3.0)
-      rubocop-ast (>= 1.32.2, < 2.0)
+      rubocop-ast (>= 1.36.1, < 2.0)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 2.4.0, < 3.0)
-    rubocop-ast (1.33.0)
+      unicode-display_width (>= 2.4.0, < 4.0)
+    rubocop-ast (1.36.2)
       parser (>= 3.3.1.0)
     rubocop-rake (0.6.0)
       rubocop (~> 1.0)
@@ -76,8 +76,10 @@ GEM
     sawyer (0.9.2)
       addressable (>= 2.3.5)
       faraday (>= 0.17.3, < 3)
-    unicode-display_width (2.6.0)
-    uri (0.13.1)
+    unicode-display_width (3.1.2)
+      unicode-emoji (~> 4.0, >= 4.0.4)
+    unicode-emoji (4.0.4)
+    uri (1.0.2)
 
 PLATFORMS
   ruby
@@ -97,4 +99,4 @@ DEPENDENCIES
   rubocop-rspec
 
 BUNDLED WITH
-   2.5.18
+   2.5.23


### PR DESCRIPTION
**Updated RubyGems:**

* [ ] [faraday](https://github.com/lostisland/faraday): [`2.12.0...2.12.1`](https://github.com/lostisland/faraday/compare/v2.12.0...v2.12.1)
* [ ] [faraday-net_http](https://github.com/lostisland/faraday-net_http): [`3.3.0...3.4.0`](https://github.com/lostisland/faraday-net_http/compare/v3.3.0...v3.4.0)
* [ ] [json](https://github.com/ruby/json): [`2.7.5...2.8.2`](https://github.com/ruby/json/compare/v2.7.5...v2.8.2)
* [ ] [net-http](https://github.com/ruby/net-http): [`0.4.1...0.5.0`](https://github.com/ruby/net-http/compare/v0.4.1...v0.5.0)
* [ ] [ostruct](https://github.com/ruby/ostruct): [`0.6.0...0.6.1`](https://github.com/ruby/ostruct/compare/v0.6.0...v0.6.1)
* [ ] [parser](https://github.com/whitequark/parser): [`3.3.5.1...3.3.6.0`](https://github.com/whitequark/parser/compare/v3.3.5.1...v3.3.6.0)
* [ ] [regexp_parser](https://github.com/ammar/regexp_parser): [`2.9.2...2.9.3`](https://github.com/ammar/regexp_parser/compare/v2.9.2...v2.9.3)
* [ ] [rubocop](https://github.com/rubocop/rubocop): [`1.68.0...1.69.0`](https://github.com/rubocop/rubocop/compare/v1.68.0...v1.69.0)
* [ ] [rubocop-ast](https://github.com/rubocop/rubocop-ast): [`1.33.0...1.36.2`](https://github.com/rubocop/rubocop-ast/compare/v1.33.0...v1.36.2)
* [ ] [unicode-display_width](https://github.com/janlelis/unicode-display_width): [`2.6.0...3.1.2`](https://github.com/janlelis/unicode-display_width/compare/v2.6.0...v3.1.2)
* [ ] [uri](https://github.com/ruby/uri): [`0.13.1...1.0.2`](https://github.com/ruby/uri/compare/v0.13.1...v1.0.2)

Powered by [circleci-bundle-update-pr](https://rubygems.org/gems/circleci-bundle-update-pr)
