### PR TITLE
Support Ruby 3.4 and set to the default

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ executors:
     parameters:
       ruby_version:
         type: enum
-        enum: ['3.0', '3.1', '3.2', '3.3']
+        enum: ['3.0', '3.1', '3.2', '3.3', '3.4']
     docker:
       - image: cimg/ruby:<< parameters.ruby_version >>
     working_directory: ~/repo
@@ -23,7 +23,7 @@ commands:
     parameters:
       ruby_version:
         type: enum
-        enum: ['3.0', '3.1', '3.2', '3.3']
+        enum: ['3.0', '3.1', '3.2', '3.3', '3.4']
     steps:
       - restore_cache:
           name: Restore bundle cache
@@ -34,7 +34,7 @@ commands:
     parameters:
       ruby_version:
         type: enum
-        enum: ['3.0', '3.1', '3.2', '3.3']
+        enum: ['3.0', '3.1', '3.2', '3.3', '3.4']
     steps:
       - save_cache:
           name: Save bundle cache
@@ -47,7 +47,7 @@ jobs:
     parameters:
       ruby_version:
         type: enum
-        enum: ['3.0', '3.1', '3.2', '3.3']
+        enum: ['3.0', '3.1', '3.2', '3.3', '3.4']
     executor:
       name: default
       ruby_version: << parameters.ruby_version >>
@@ -70,12 +70,12 @@ jobs:
   continuous_bundle_update:
     executor:
       name: default
-      ruby_version: '3.3'
+      ruby_version: '3.4'
     steps:
       - setup_requirements
       - checkout
       - restore_bundle_cache:
-          ruby_version: '3.3'
+          ruby_version: '3.4'
       - run:
           name: Install edge circleci-bundle-update-pr
           command: |
@@ -102,6 +102,9 @@ workflows:
       - build:
           name: ruby-3.3
           ruby_version: '3.3'
+      - build:
+          name: ruby-3.4
+          ruby_version: '3.4'
   nightly:
     triggers:
       - schedule:

--- a/circleci-bundle-update-pr.gemspec
+++ b/circleci-bundle-update-pr.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 3.0.0'
 
-  spec.add_dependency 'compare_linker', '>= 1.4.5'
+  spec.add_dependency 'compare_linker', '>= 1.4.10'
   spec.add_dependency 'octokit'
 
   spec.add_development_dependency 'bundler'


### PR DESCRIPTION
https://www.ruby-lang.org/en/news/2024/12/25/ruby-3-4-0-released/
https://www.ruby-lang.org/en/news/2024/12/25/ruby-3-4-1-released/
