### PR TITLE
bundle update at 2025-03-01 19:11:15 JST

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,23 +12,24 @@ GEM
       public_suffix (>= 2.0.2, < 7.0)
     ast (2.4.2)
     base64 (0.2.0)
-    compare_linker (1.4.10)
+    compare_linker (1.4.11)
       base64
       httpclient
-      mutex_m
       octokit
       ostruct
-    diff-lcs (1.5.1)
+    diff-lcs (1.6.0)
     faraday (2.12.2)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
     faraday-net_http (3.4.0)
       net-http (>= 0.5.0)
-    httpclient (2.8.3)
-    json (2.9.1)
+    httpclient (2.9.0)
+      mutex_m
+    json (2.10.1)
     language_server-protocol (3.17.0.4)
-    logger (1.6.5)
+    lint_roller (1.1.0)
+    logger (1.6.6)
     mutex_m (0.3.0)
     net-http (0.6.0)
       uri
@@ -37,7 +38,7 @@ GEM
       sawyer (~> 0.9)
     ostruct (0.6.1)
     parallel (1.26.3)
-    parser (3.3.7.0)
+    parser (3.3.7.1)
       ast (~> 2.4.1)
       racc
     public_suffix (6.0.1)
@@ -49,7 +50,7 @@ GEM
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
       rspec-mocks (~> 3.13.0)
-    rspec-core (3.13.2)
+    rspec-core (3.13.3)
       rspec-support (~> 3.13.0)
     rspec-expectations (3.13.3)
       diff-lcs (>= 1.2.0, < 2.0)
@@ -58,9 +59,10 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
     rspec-support (3.13.2)
-    rubocop (1.71.1)
+    rubocop (1.73.1)
       json (~> 2.3)
-      language_server-protocol (>= 3.17.0)
+      language_server-protocol (~> 3.17.0.2)
+      lint_roller (~> 1.1.0)
       parallel (~> 1.10)
       parser (>= 3.3.0.2)
       rainbow (>= 2.2.2, < 4.0)
@@ -68,12 +70,14 @@ GEM
       rubocop-ast (>= 1.38.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 4.0)
-    rubocop-ast (1.38.0)
+    rubocop-ast (1.38.1)
       parser (>= 3.3.1.0)
-    rubocop-rake (0.6.0)
-      rubocop (~> 1.0)
-    rubocop-rspec (3.4.0)
-      rubocop (~> 1.61)
+    rubocop-rake (0.7.1)
+      lint_roller (~> 1.1)
+      rubocop (>= 1.72.1)
+    rubocop-rspec (3.5.0)
+      lint_roller (~> 1.1)
+      rubocop (~> 1.72, >= 1.72.1)
     ruby-progressbar (1.13.0)
     sawyer (0.9.2)
       addressable (>= 2.3.5)
@@ -81,7 +85,7 @@ GEM
     unicode-display_width (3.1.4)
       unicode-emoji (~> 4.0, >= 4.0.4)
     unicode-emoji (4.0.4)
-    uri (1.0.2)
+    uri (1.0.3)
 
 PLATFORMS
   ruby
@@ -101,4 +105,4 @@ DEPENDENCIES
   rubocop-rspec
 
 BUNDLED WITH
-   2.6.2
+   2.6.3


### PR DESCRIPTION
**Updated RubyGems:**

* [ ] [compare_linker](https://github.com/masutaka/compare_linker): [`1.4.10...1.4.11`](https://github.com/masutaka/compare_linker/compare/v1.4.10...v1.4.11)
* [ ] [diff-lcs](https://github.com/halostatue/diff-lcs): [`1.5.1...1.6.0`](https://github.com/halostatue/diff-lcs/compare/v1.5.1...v1.6.0)
* [ ] [httpclient](https://github.com/nahi/httpclient): [`2.8.3...2.9.0`](https://github.com/nahi/httpclient/compare/v2.8.3...v2.9.0)
* [ ] [json](https://github.com/ruby/json): [`2.9.1...2.10.1`](https://github.com/ruby/json/compare/v2.9.1...v2.10.1)
* [ ] [logger](https://github.com/ruby/logger): [`1.6.5...1.6.6`](https://github.com/ruby/logger/compare/v1.6.5...v1.6.6)
* [ ] [parser](https://github.com/whitequark/parser): [`3.3.7.0...3.3.7.1`](https://github.com/whitequark/parser/compare/v3.3.7.0...v3.3.7.1)
* [ ] [rspec-core](https://github.com/rspec/rspec-core): `3.13.2...3.13.3`
* [ ] [rubocop](https://github.com/rubocop/rubocop): [`1.71.1...1.73.1`](https://github.com/rubocop/rubocop/compare/v1.71.1...v1.73.1)
* [ ] [rubocop-ast](https://github.com/rubocop/rubocop-ast): [`1.38.0...1.38.1`](https://github.com/rubocop/rubocop-ast/compare/v1.38.0...v1.38.1)
* [ ] [rubocop-rake](https://github.com/rubocop/rubocop-rake): [`0.6.0...0.7.1`](https://github.com/rubocop/rubocop-rake/compare/v0.6.0...v0.7.1)
* [ ] [rubocop-rspec](https://github.com/rubocop/rubocop-rspec): [`3.4.0...3.5.0`](https://github.com/rubocop/rubocop-rspec/compare/v3.4.0...v3.5.0)
* [ ] [uri](https://github.com/ruby/uri): [`1.0.2...1.0.3`](https://github.com/ruby/uri/compare/v1.0.2...v1.0.3)

Powered by [circleci-bundle-update-pr](https://rubygems.org/gems/circleci-bundle-update-pr)
