### PR TITLE
Fix rubocop warnings

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 inherit_from: .rubocop_todo.yml
-require:
+plugins:
   - rubocop-rake
   - rubocop-rspec
 


### PR DESCRIPTION
```console
$ bundle exec rubocop
rubocop-rake extension supports plugin, specify `plugins: rubocop-rake` instead of `require: rubocop-rake` in /Users/masutaka/src/github.com/masutaka/circleci-bundle-update-pr/.rubocop.yml.
For more information, see https://docs.rubocop.org/rubocop/plugin_migration_guide.html.

rubocop-rspec extension supports plugin, specify `plugins: rubocop-rspec` instead of `require: rubocop-rspec` in /Users/masutaka/src/github.com/masutaka/circleci-bundle-update-pr/.rubocop.yml.
For more information, see https://docs.rubocop.org/rubocop/plugin_migration_guide.html.

Inspecting 10 files
..........

10 files inspected, no offenses detected
```
