### PR TITLE
bundle update at 2025-05-01 19:11:05 JST

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,7 +18,7 @@ GEM
       octokit
       ostruct
     diff-lcs (1.6.1)
-    faraday (2.12.2)
+    faraday (2.13.1)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
@@ -26,23 +26,23 @@ GEM
       net-http (>= 0.5.0)
     httpclient (2.9.0)
       mutex_m
-    json (2.10.2)
+    json (2.11.3)
     language_server-protocol (3.17.0.4)
     lint_roller (1.1.0)
     logger (1.7.0)
     mutex_m (0.3.0)
     net-http (0.6.0)
       uri
-    octokit (9.2.0)
+    octokit (10.0.0)
       faraday (>= 1, < 3)
       sawyer (~> 0.9)
     ostruct (0.6.1)
-    parallel (1.26.3)
-    parser (3.3.7.4)
+    parallel (1.27.0)
+    parser (3.3.8.0)
       ast (~> 2.4.1)
       racc
     prism (1.4.0)
-    public_suffix (6.0.1)
+    public_suffix (6.0.2)
     racc (1.8.1)
     rainbow (3.1.1)
     rake (13.2.1)
@@ -53,14 +53,14 @@ GEM
       rspec-mocks (~> 3.13.0)
     rspec-core (3.13.3)
       rspec-support (~> 3.13.0)
-    rspec-expectations (3.13.3)
+    rspec-expectations (3.13.4)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
-    rspec-mocks (3.13.2)
+    rspec-mocks (3.13.3)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
-    rspec-support (3.13.2)
-    rubocop (1.75.1)
+    rspec-support (3.13.3)
+    rubocop (1.75.4)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)
@@ -68,16 +68,16 @@ GEM
       parser (>= 3.3.0.2)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 2.9.3, < 3.0)
-      rubocop-ast (>= 1.43.0, < 2.0)
+      rubocop-ast (>= 1.44.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 4.0)
-    rubocop-ast (1.43.0)
+    rubocop-ast (1.44.1)
       parser (>= 3.3.7.2)
       prism (~> 1.4)
     rubocop-rake (0.7.1)
       lint_roller (~> 1.1)
       rubocop (>= 1.72.1)
-    rubocop-rspec (3.5.0)
+    rubocop-rspec (3.6.0)
       lint_roller (~> 1.1)
       rubocop (~> 1.72, >= 1.72.1)
     ruby-progressbar (1.13.0)
@@ -107,4 +107,4 @@ DEPENDENCIES
   rubocop-rspec
 
 BUNDLED WITH
-   2.6.3
+   2.6.8


### PR DESCRIPTION
**Updated RubyGems:**

* [ ] [faraday](https://github.com/lostisland/faraday): [`2.12.2...2.13.1`](https://github.com/lostisland/faraday/compare/v2.12.2...v2.13.1)
* [ ] [json](https://github.com/ruby/json): [`2.10.2...2.11.3`](https://github.com/ruby/json/compare/v2.10.2...v2.11.3)
* [ ] [octokit](https://github.com/octokit/octokit.rb): [`9.2.0...10.0.0`](https://github.com/octokit/octokit.rb/compare/v9.2.0...v10.0.0)
* [ ] [parallel](https://github.com/grosser/parallel): [`1.26.3...1.27.0`](https://github.com/grosser/parallel/compare/v1.26.3...v1.27.0)
* [ ] [parser](https://github.com/whitequark/parser): [`3.3.7.4...3.3.8.0`](https://github.com/whitequark/parser/compare/v3.3.7.4...v3.3.8.0)
* [ ] [public_suffix](https://github.com/weppos/publicsuffix-ruby): [`6.0.1...6.0.2`](https://github.com/weppos/publicsuffix-ruby/compare/v6.0.1...v6.0.2)
* [ ] [rspec-expectations](https://github.com/rspec/rspec-expectations): `3.13.3...3.13.4`
* [ ] [rspec-mocks](https://github.com/rspec/rspec-mocks): `3.13.2...3.13.3`
* [ ] [rspec-support](https://github.com/rspec/rspec-support): `3.13.2...3.13.3`
* [ ] [rubocop](https://github.com/rubocop/rubocop): [`1.75.1...1.75.4`](https://github.com/rubocop/rubocop/compare/v1.75.1...v1.75.4)
* [ ] [rubocop-ast](https://github.com/rubocop/rubocop-ast): [`1.43.0...1.44.1`](https://github.com/rubocop/rubocop-ast/compare/v1.43.0...v1.44.1)
* [ ] [rubocop-rspec](https://github.com/rubocop/rubocop-rspec): [`3.5.0...3.6.0`](https://github.com/rubocop/rubocop-rspec/compare/v3.5.0...v3.6.0)

Powered by [circleci-bundle-update-pr](https://rubygems.org/gems/circleci-bundle-update-pr)
