### PR TITLE
bundle update at 2025-06-01 19:11:04 JST

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,13 +11,13 @@ GEM
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
     ast (2.4.3)
-    base64 (0.2.0)
+    base64 (0.3.0)
     compare_linker (1.4.11)
       base64
       httpclient
       octokit
       ostruct
-    diff-lcs (1.6.1)
+    diff-lcs (1.6.2)
     faraday (2.13.1)
       faraday-net_http (>= 2.0, < 3.5)
       json
@@ -26,8 +26,8 @@ GEM
       net-http (>= 0.5.0)
     httpclient (2.9.0)
       mutex_m
-    json (2.11.3)
-    language_server-protocol (3.17.0.4)
+    json (2.12.2)
+    language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     logger (1.7.0)
     mutex_m (0.3.0)
@@ -45,22 +45,22 @@ GEM
     public_suffix (6.0.2)
     racc (1.8.1)
     rainbow (3.1.1)
-    rake (13.2.1)
+    rake (13.3.0)
     regexp_parser (2.10.0)
-    rspec (3.13.0)
+    rspec (3.13.1)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
       rspec-mocks (~> 3.13.0)
-    rspec-core (3.13.3)
+    rspec-core (3.13.4)
       rspec-support (~> 3.13.0)
-    rspec-expectations (3.13.4)
+    rspec-expectations (3.13.5)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
-    rspec-mocks (3.13.3)
+    rspec-mocks (3.13.5)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
-    rspec-support (3.13.3)
-    rubocop (1.75.4)
+    rspec-support (3.13.4)
+    rubocop (1.75.8)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)
@@ -107,4 +107,4 @@ DEPENDENCIES
   rubocop-rspec
 
 BUNDLED WITH
-   2.6.8
+   2.6.9


### PR DESCRIPTION
**Updated RubyGems:**

* [ ] [base64](https://github.com/ruby/base64): [`0.2.0...0.3.0`](https://github.com/ruby/base64/compare/v0.2.0...v0.3.0)
* [ ] [diff-lcs](https://github.com/halostatue/diff-lcs): [`1.6.1...1.6.2`](https://github.com/halostatue/diff-lcs/compare/v1.6.1...v1.6.2)
* [ ] [json](https://github.com/ruby/json): [`2.11.3...2.12.2`](https://github.com/ruby/json/compare/v2.11.3...v2.12.2)
* [ ] [language_server-protocol](https://github.com/mtsmfm/language_server-protocol-ruby): [`3.17.0.4...3.17.0.5`](https://github.com/mtsmfm/language_server-protocol-ruby/compare/v3.17.0.4...v3.17.0.5)
* [ ] [rake](https://github.com/ruby/rake): [`13.2.1...13.3.0`](https://github.com/ruby/rake/compare/v13.2.1...v13.3.0)
* [ ] rspec: (link not found) `3.13.0...3.13.1`
* [ ] [rspec-core](https://github.com/rspec/rspec-core): `3.13.3...3.13.4`
* [ ] [rspec-expectations](https://github.com/rspec/rspec-expectations): `3.13.4...3.13.5`
* [ ] [rspec-mocks](https://github.com/rspec/rspec-mocks): `3.13.3...3.13.5`
* [ ] [rspec-support](https://github.com/rspec/rspec-support): `3.13.3...3.13.4`
* [ ] [rubocop](https://github.com/rubocop/rubocop): [`1.75.4...1.75.8`](https://github.com/rubocop/rubocop/compare/v1.75.4...v1.75.8)

Powered by [circleci-bundle-update-pr](https://rubygems.org/gems/circleci-bundle-update-pr)
